### PR TITLE
Add a GitHub Action proposing the creation of RFC referenda

### DIFF
--- a/.github/workflows/rfc-propose.yml
+++ b/.github/workflows/rfc-propose.yml
@@ -1,0 +1,18 @@
+name: RFC propose
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  rfc-propose:
+    name: Propose an RFC creation transaction
+    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/rfc-propose') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: paritytech/rfc-propose@ae558a3c03f562362b78babdc72697f5f5fbb3af # v0.0.1
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- The action aims to help with the creation of the RFC on-chain referenda.
- The action will respond to `/rfc-propose` comments on RFC PRs.
- The output of the action will [look like that](https://github.com/paritytech-stg/RFCs/pull/5#issuecomment-1700852905).
- Related to https://github.com/polkadot-fellows/RFCs/issues/21