### PR TITLE
Fixed issue with RFC-Cron

### DIFF
--- a/.github/workflows/rfc-referenda-notifications.yml
+++ b/.github/workflows/rfc-referenda-notifications.yml
@@ -3,7 +3,7 @@ name: RFC Cron
 on:
     workflow_dispatch:
     schedule:
-      - cron: '* 11 * * *'
+      - cron: '0 12 * * 1,2,3,4,5'
   
 jobs:
   test_run:

--- a/.github/workflows/rfc-referenda-notifications.yml
+++ b/.github/workflows/rfc-referenda-notifications.yml
@@ -6,8 +6,9 @@ on:
       - cron: '0 12 * * 1,2,3,4,5'
   
 jobs:
-  test_run:
+  rfc_notification:
     runs-on: ubuntu-latest
+    name: Notify on referendas
     steps:
         - name: Get last run
           run: |

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Problems, requirements, and descriptions in RFC text should be stated using the 
 
 ## Bots
 
+[![RFC Cron](https://github.com/polkadot-fellows/RFCs/actions/workflows/rfc-referenda-notifications.yml/badge.svg)](https://github.com/polkadot-fellows/RFCs/actions/workflows/rfc-referenda-notifications.yml)
+
 The repository provides a bot for:
 
 * Proposing RFCs on chain in a referenda to let the fellowship vote on the RFC. The referenda can only be created by accounts that are part of the fellowship.


### PR DESCRIPTION
It was improperly set to run every minute after 11. I changed it to run every weekday only once after 12.

Also, added status badge for the job in the Readme so we can preview there that the job is running:
[![RFC Cron](https://github.com/polkadot-fellows/RFCs/actions/workflows/rfc-referenda-notifications.yml/badge.svg)](https://github.com/polkadot-fellows/RFCs/actions/workflows/rfc-referenda-notifications.yml)