### PR TITLE
mdBook: Strip down links in RFCs titles

### DIFF
--- a/.github/scripts/build-mdbook-summary.js
+++ b/.github/scripts/build-mdbook-summary.js
@@ -15,9 +15,15 @@ module.exports = async ({github, context}) => {
       if (!filename.endsWith(".md")) continue;
       const filePath = dirPath + filename
       const text = fs.readFileSync(filePath)
-      const title = text.toString().split(/\n/)
+      let title = text.toString().split(/\n/)
         .find(line => line.startsWith("# ") || line.startsWith(" # "))
         .replace("# ", "")
+      for (const markdownLink of title.matchAll(/\[(.*?)\]\((.*?)\)/g)) {
+        // Replace any [label](destination) markdown links in the title with just the label.
+        // This is because the titles are turned into links themselves,
+        // and we cannot have a link inside of a link - it breaks markdown and mdBook is not able to build.
+        title = title.replace(markdownLink[0], markdownLink[1])
+      }
       // Relative path, without the src prefix (format required by mdbook)
       const relativePath = filePath.replace("mdbook/src/", "")
       fs.appendFileSync(summaryPath, `- [${title}](${relativePath})\n`)

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - rzadp/strip-links
   schedule:
     - cron: "0 0 * * *" # Once a day
 

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - rzadp/strip-links
   schedule:
     - cron: "0 0 * * *" # Once a day
 


### PR DESCRIPTION
- Closes https://github.com/polkadot-fellows/RFCs/issues/71
- This affects only the sidebar of the mdBook.

![Screenshot 2024-01-31 at 12 39 38](https://github.com/polkadot-fellows/RFCs/assets/12039224/715f1856-1bf4-48be-9669-e3487c732658)
