### PR TITLE
updated rfc-action to 0.1.0 (inform on closed referendas)

### DIFF
--- a/.github/workflows/rfc-action.yml
+++ b/.github/workflows/rfc-action.yml
@@ -15,11 +15,10 @@ jobs:
     steps:
       - name: Generate a token
         id: generate_token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v1.8.1
         with:
-          app_id: ${{ secrets.RFC_BOT_APP_ID }}
-          private_key: ${{ secrets.RFC_BOT_PRIVATE_KEY }}
-      - uses: paritytech/rfc-action@c673cf6776a2f266c7d8cbb29bc2159bea2cdd78 # v0.0.6
+          app-id: ${{ secrets.RFC_BOT_APP_ID }}
+          private-key: ${{ secrets.RFC_BOT_PRIVATE_KEY }}
       - uses: paritytech/rfc-action@4b7d2a911220b32f2222e083fd32aa62f17739c4 # v0.1.0
         env:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/rfc-action.yml
+++ b/.github/workflows/rfc-action.yml
@@ -20,5 +20,6 @@ jobs:
           app_id: ${{ secrets.RFC_BOT_APP_ID }}
           private_key: ${{ secrets.RFC_BOT_PRIVATE_KEY }}
       - uses: paritytech/rfc-action@c673cf6776a2f266c7d8cbb29bc2159bea2cdd78 # v0.0.6
+      - uses: paritytech/rfc-action@4b7d2a911220b32f2222e083fd32aa62f17739c4 # v0.1.0
         env:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
This includes https://github.com/paritytech/rfc-action/pull/34 which takes into consideration successful RFCs.

When a RFC closed after the last run, it will comment on the open PR (if it is still open) that the RFC has been closed and how to trigger the bot to merge the PR.

If it is succesfull, we can automate it to simply close the PRs without human input.

Also, updated actions/create-github-app-token to latest (version `1.8.1`)