### PR TITLE
rfc-cron: updated cron to v0.1.1

### DIFF
--- a/.github/workflows/rfc-referenda-notifications.yml
+++ b/.github/workflows/rfc-referenda-notifications.yml
@@ -3,7 +3,7 @@ name: RFC Cron
 on:
     workflow_dispatch:
     schedule:
-      - cron: '0 12 * * *'
+      - cron: '0 12,18 * * *'
   
 jobs:
   rfc_notification:

--- a/.github/workflows/rfc-referenda-notifications.yml
+++ b/.github/workflows/rfc-referenda-notifications.yml
@@ -19,7 +19,7 @@ jobs:
            GH_TOKEN: ${{ github.token }}
            WORKFLOW: ${{ github.workflow }}
            GH_REPO: "${{ github.repository_owner }}/${{ github.event.repository.name }}"
-        - uses: paritytech/rfc-action@v0.0.8
+        - uses: paritytech/rfc-action@v0.1.1
           env:
             GH_TOKEN: ${{ github.token }}
             PROVIDER_URL: "wss://polkadot-collectives-rpc.polkadot.io"


### PR DESCRIPTION
When doing #80 I got confused and updated the wrong action (which uses the same dependency).

This one updates the RFC action for the cron job

---

When a RFC closes after the last run, it will comment on the open PR (if it is still open) that the RFC has been closed and how to trigger the bot to merge the PR.

If it is succesfull, we can automate it to simply close the PRs without human input.

### Miscellaneous changes

- Also, updated cron job to run at mid day and at end of the day so we can capture new RFCs more often.
- `v0.1.1` also has a fix for a problem with LFS files not being downloaded by the GitHub Actions that was discovered and fixed in paritytech/rfc-action#37 by @rzadp.