### PR TITLE
Introduce a transaction extension version

### DIFF
--- a/text/0099-transaction-extension-version.md
+++ b/text/0099-transaction-extension-version.md
@@ -44,7 +44,7 @@ In the chain runtime the version can be used to determine which set of transacti
 
 ## Drawbacks
 
-This adds a least one byte more to each signed transaction. 
+This adds one byte more to each signed transaction. 
 
 ## Testing, Security, and Privacy
 


### PR DESCRIPTION
This RFC proposes to introduce a transaction extensions version. It is proposed to piggyback on [RFC84](https://github.com/paritytech/polkadot-sdk/issues/2415) to not require a new extrinsic format version. With this RFC it will be possible to change the transaction extensions without breaking the extrinsic format of a chain and thus, staying backwards compatible.