### PR TITLE
Constrain parachain block validity on a specific core

### DIFF
--- a/text/0102-introduce-core-index-commitment.md
+++ b/text/0102-introduce-core-index-commitment.md
@@ -1,0 +1,191 @@
+# RFC-0102:  Introduce a `CoreIndex` commitment in candidate receipts
+
+|                 |                                                                                             |
+| --------------- | ------------------------------------------------------------------------------------------- |
+| **Start Date**  | 15 July 2024                                                                    |
+| **Description** | Constrain parachain block validity on a single core                                                                   |
+| **Authors**     | Andrei Sandu                                                                                            |
+
+## Summary
+The only requirement for collator nodes is to provide valid parachain blocks to the validators of a backing group and by definition the collator set is trustless. However, in the case of elastic scaling, for security reason, collators must be trusted - non-malicious. `CoreIndex` commitments are required to remove this limitation.
+
+## Motivation
+
+At present time misbehaving collator nodes can prevent their parachain from effecitvely using elastic scaling by providing the same valid block to all backing groups assigned to the parachain. This happens before the next parachain block is authored and will prevent the chain of candidates to be formed, reducing the throughput of the parachain to a single core.
+There are no special requirements from collators to do it, just being a full node is sufficient and there are no methods of punishing or rewarding good behaviour.
+
+This RFC solves the problem by enabling a parachain to provide the core index information as part of it's PVF execution output and in the associated candidate receipt data structure. 
+
+Once this RFC is implemented the validity of a parachain block depends on the core it is being executed on.
+
+## Stakeholders
+
+- Polkadot core developers.
+- Cumulus node developers.
+- Tooling, block explorer developers.
+
+This approach and alternatives have been considered and discussed in [this issue](https://github.com/polkadot-fellows/RFCs/issues/92).
+
+## Explanation
+
+The approach proposed below was chosen primarly because it minimizes the number of breaking changes, the complexity and takes far less implementation and testing time. The proposal is to free up space and introduce a new core index field in the `CandidateDescriptor` primitive and use the UMP queue as output for `CoreIndex` commitment. 
+
+### Reclaiming unused space in the descriptor
+The `CandidateDescriptor` currently includes `collator` and `signature` fields. The collator includes a signature on the following descriptor fields: parachain id, relay parent, validation data hash, validation code hash and the PoV hash.
+
+However, in practice, having a collator signature in the receipt on the relay chain does not provide any benefits as there is no mechanism to punish or reward collators that have provided bad parachain blocks.
+
+This proposal aims to remove the two fields and all the logic that checks the collator signatures. We reclaim the unused space as `reserved` fields and fill it with zeroes, so there is no change in the layout and lenght of the receipt. The new primitive binary compatible with the old one.
+
+
+### Backwards compatibility
+
+There are two flavors of candidate receipts which are used in network protocols, runtime and node implementation:
+- `CommittedCandidateReceipt` which includes the `CanidateDescriptor` and the `CandidateCommitments` 
+- `CandidateReceipt` which includes the `CanidateDescriptor` and just a hash of the commitments
+
+We want to support both the old and new versions in the runtime and node . The implementation must be able to detect the version of a given candidate receipt.
+
+This is easy to do in both cases:
+- the reserved fields are zeroed
+- the UMP queue contains the core index commitment that matches the core index in the descriptor.
+
+
+### Polkadot Primitive changes
+
+#### New [CandidateDescriptor](https://github.com/paritytech/polkadot-sdk/blob/master/polkadot/primitives/src/v7/mod.rs#L482)
+
+- reclaim 32 bytes from `collator: CollatorId` and 64 bytes from `signature: CollatorSignature` as `reserved` 
+- use 4 bytes for a new `core_index: CoreIndex` field.
+- the unused reclaimed space will be filled with zeroes
+
+Thew new primitive will look like this:
+```
+pub struct CandidateDescriptor<H = Hash> {
+	/// The ID of the para this is a candidate for.
+	pub para_id: Id,
+	/// The hash of the relay-chain block this is executed in the context of.
+	pub relay_parent: H,
+	/// The core index where the candidate is backed.
+	pub core_index: CoreIndex,
+	/// Reserved bytes.
+	pub reserved1: [u8; 28],
+	/// The blake2-256 hash of the persisted validation data. This is extra data derived from
+	/// relay-chain state which may vary based on bitfields included before the candidate.
+	/// Thus it cannot be derived entirely from the relay-parent.
+	pub persisted_validation_data_hash: Hash,
+	/// The blake2-256 hash of the PoV.
+	pub pov_hash: Hash,
+	/// The root of a block's erasure encoding Merkle tree.
+	pub erasure_root: Hash,
+	/// Reserved bytes.
+	pub reserved2: [u8; 64],
+	/// Hash of the para header that is being generated by this candidate.
+	pub para_head: Hash,
+	/// The blake2-256 hash of the validation code bytes.
+	pub validation_code_hash: ValidationCodeHash,
+}
+
+```
+
+In the future, parts of the `reserved1` and `reserved2` bytes can be used to include additional information in the descriptor.
+
+**Introduce new primitive for representing the `CoreIndex` commitment as an enum to allow future additions.**
+
+
+```
+pub enum UMPSignal {
+	OnCore(CoreIndex),
+}
+```
+### Cumulus primitives
+
+Add a new version of the `ParachainInherentData` structure which includes an additional `core_index` field.
+```
+pub struct ParachainInherentData {
+	pub validation_data: PersistedValidationData,
+	/// A storage proof of a predefined set of keys from the relay-chain.
+	///
+	/// Specifically this witness contains the data for:
+	///
+	/// - the current slot number at the given relay parent
+	/// - active host configuration as per the relay parent,
+	/// - the relay dispatch queue sizes
+	/// - the list of egress HRMP channels (in the list of recipients form)
+	/// - the metadata for the egress HRMP channels
+	pub relay_chain_state: sp_trie::StorageProof,
+	/// Downward messages in the order they were sent.
+	pub downward_messages: Vec<InboundDownwardMessage>,
+	/// HRMP messages grouped by channels. The messages in the inner vec must be in order they
+	/// were sent. In combination with the rule of no more than one message in a channel per block,
+	/// this means `sent_at` is **strictly** greater than the previous one (if any).
+	pub horizontal_messages: BTreeMap<ParaId, Vec<InboundHrmpMessage>>,
+        /// The core index on which the parachain block must be backed
+        pub core_index: CoreIndex,
+}
+```
+
+### UMP transport
+[CandidateCommitments](https://github.com/paritytech/polkadot-sdk/blob/master/polkadot/primitives/src/v7/mod.rs#L652) remains unchanged as we will store scale encoded `UMPSignal` messages directly in the parachain UMP queue by outputing them in the [upward_messages](https://github.com/paritytech/polkadot-sdk/blob/master/polkadot/primitives/src/v7/mod.rs#L682). 
+
+
+The UMP queue layout is adjusted to allow the relay chain to receive both the XCM messages and `UMPSignal` messages. We will introduce a message separator that will be implemented as an empty `Vec<u8>`.
+
+The separator marks the end of the XCM messages and the begging of the `UMPSignal` messages.
+
+Example: 
+```
+[ XCM message1, XCM message2, ..., EMPTY message, UMPSignal::CoreIndex ]
+```
+
+### Parachain block validation
+Backers will make use of the core index information to validate the blocks during backing and reject blocks if:
+- the `core_index` in descriptor does not match the one in the `UMPSignal`.
+- the `core_index` in the descriptor does not match the core the backing group is assigned to
+
+If core index information is not available (backers got an old candidate receipt), there will be no changes compared to current behaviour.
+
+## Drawbacks
+
+The only drawback is that further additions to the descriptor are limited to the amount of remaining unused space.
+
+
+## Testing, Security, and Privacy
+
+Standard testing (unit tests, CI zombienet tests) for functionality and mandatory secuirty audit to ensure the implementation does not introduce any new security issues.
+
+Backwards compatibility of the implementation will be tested on testnets (Versi and Westend).
+
+There is no impact on privacy.
+
+## Performance
+
+The expectation is that performance impact is negligible for sending and processing the UMP message has negligible performance impact in the runtime as well as on the node side.
+
+## Ergonomics
+
+Parachain that use elastic scaling must send the separator empty message followed by the `UMPSignal::OnCore` only after sending all of the UMP XCM messages.
+
+## Compatibility
+
+To ensure a smooth transition the first step is to remove collator signature checking logic on the node side and upgrade validators. Any tooling that uses these fields will require similar changes as described above to support both formats.
+
+The runtime does not check the collator signature so there are no other specific concers for compatibility except adding the support for the new primitives.
+
+
+`CoreIndex` commitments are mandatory only for parachains using elastic scaling. No new implementation of networking protocol versions for collation and validation are required.
+
+
+## Prior Art and References
+
+Forum discussion about a new `CandidateReceipt` format: https://forum.polkadot.network/t/pre-rfc-discussion-candidate-receipt-format-v2/3738
+
+## Unresolved Questions
+
+N/A
+
+## Future Directions and Related Material
+
+The implementation is extensible and future proof to some extent. With minimal or no breaking changes, additional fields can be added in the candidate descriptor until the reserved space is exhausted
+
+Once the reserved space is exhausted, versioning will be implemented. The candidate receipt format will be versioned. This will exteend to pvf execution which requires versioning for the validation function, inputs and outputs (`CandidateCommitments`).

--- a/text/0103-introduce-core-index-commitment.md
+++ b/text/0103-introduce-core-index-commitment.md
@@ -1,4 +1,4 @@
-# RFC-0102:  Introduce a `CoreIndex` commitment in candidate receipts
+# RFC-0103:  Introduce a `CoreIndex` commitment in candidate receipts
 
 |                 |                                                                                             |
 | --------------- | ------------------------------------------------------------------------------------------- |

--- a/text/0103-introduce-core-index-commitment.md
+++ b/text/0103-introduce-core-index-commitment.md
@@ -155,7 +155,7 @@ pub struct CandidateDescriptorV2<H = Hash> {
 	version: InternalVersion,
 	/// The core index where the candidate is backed.
 	core_index: u16,
-	/// The session index of the candidate relay parent.
+	/// The session in which the candidate is backed.
 	session_index: SessionIndex,
 	/// Reserved bytes.
 	reserved1: [u8; 25],
@@ -278,9 +278,9 @@ the new candidate receipts format.
 
 ### Validators
 
-To ensure a smooth launch, a new node feature is required. 
+To ensure a smooth launch, a new node feature is required.
 The feature acts as a signal for supporting the new candidate receipts on the node side and can 
-only be safely enabled if at least `2/3 + 1` of the validators are upgraded.
+only be safely enabled if at least `2/3 + 1` of the validators are upgraded. Node implementions need to decode the new candidate descriptor once the feature is enabled otherwise they might raise disputes and get slashed.
 
 Once enabled, the validators will skip checking the collator signature when processing the 
 candidate receipts and verify the `CoreIndex` and `SessionIndex` fields if present in the receipt.

--- a/text/0103-introduce-core-index-commitment.md
+++ b/text/0103-introduce-core-index-commitment.md
@@ -189,9 +189,14 @@ The expectation is that performance impact is negligible for sending and process
 
 ## Ergonomics
 
-Parachain that use elastic scaling must send the separator empty message followed by the `UMPSignal::OnCore` only after sending all of the UMP XCM messages.
+Parachain that use elastic scaling must send the separator empty message followed by the `UMPSignal::SelectCore` only after sending all of the UMP XCM messages.
 
 ## Compatibility
+
+### Versioning
+
+At this point there is a simple way to determine the version of the receipt, by testing for zeroed reserved bytes in the
+descriptor. Supporting future changes will require a `u8` version field to be introduced in the reserved space. We consider the current version to be 0 and the version check implicitly done when checking for reserved space to be zeroed.
 
 ### Runtime
 The first step is to remove collator signature checking logic in the runtime, but keep the node side collator signature 
@@ -207,7 +212,6 @@ The feature acts as a signal for supporting the new candidate receipts on the no
 Once enabled, the validators will skip checking the collator signature when processing the candidate receipts and verify the `CoreIndex` and `SessionIndex` fields if present in the receipit.
 
 No new implementation of networking protocol versions for collation and validation are required.
-
 
 ### Parachains
 

--- a/text/0103-introduce-core-index-commitment.md
+++ b/text/0103-introduce-core-index-commitment.md
@@ -61,13 +61,13 @@ The UMP queue layout is changed to allow the relay chain to receive both the XCM
 This way of representing the new messages has been chosen over introducing an enum wrapper to minimize breaking changes of XCM message decoding in tools like Subscan for example. 
 
 Example: 
-```
+```rust
 [ XCM message1, XCM message2, ..., EMPTY message, UMPSignal::CoreSelector ]
 ```
 
 #### `UMPSignal` messages
 
-```
+```rust
 /// An `u8` wrap around sequence number. Typically this would be the least significant byte of the parachain block number.
 pub struct CoreSelector(pub u8);
 
@@ -92,7 +92,7 @@ statically to some sane value. Parachains should prefer to have a static value t
 Considering `para_assigned_cores` is a sorted vec of core indices assigned to a parachain at the
 specified claim queue offset, validators will determine the committed core index like this:
 
-```
+```rust
 let assigned_core_index = core_selector % para_assigned_cores.len();
 let committed_core_index = para_assigned_cores[assigned_core_index];
 ```

--- a/text/0103-introduce-core-index-commitment.md
+++ b/text/0103-introduce-core-index-commitment.md
@@ -90,8 +90,8 @@ The table below represents a snapshot of the claim queue:
 
 The purpose of `ClaimQueueOffset` is to select the column from the above table. 
 For `cq_offset = 1` we get `[ Para A, Para B, Para A]` and use as input to create 
-a sorted vec with the cores A is assigned to: `[ Core 1, Core 2]` and call it `para_assigned_cores`.
-We use `core_selector` and determine the commited core index is `Core 2` like this:
+a sorted vec with the cores A is assigned to: `[ Core 1, Core 3]` and call it `para_assigned_cores`.
+We use `core_selector` and determine the commited core index is `Core 3` like this:
 
 ```rust
 let committed_core_index = para_assigned_cores[core_selector % para_assigned_cores.len()];

--- a/text/0103-introduce-core-index-commitment.md
+++ b/text/0103-introduce-core-index-commitment.md
@@ -69,7 +69,7 @@ UMP queue by outputting them in [upward_messages](https://github.com/paritytech/
 
 The UMP queue layout is changed to allow the relay chain to receive both the XCM messages and
 `UMPSignal` messages. An empty message (empty `Vec<u8>`) is used to mark the end of XCM messages and
-the start of `UMPSignal` messages.The `UMPSignal` is optional and can be omitted by parachains
+the start of `UMPSignal` messages. The `UMPSignal` is optional and can be omitted by parachains
 not using elastic scaling.
 
 This way of representing the new messages has been chosen over introducing an enum wrapper to

--- a/text/0103-introduce-core-index-commitment.md
+++ b/text/0103-introduce-core-index-commitment.md
@@ -233,4 +233,4 @@ N/A
 
 The implementation is extensible and future proof to some extent. With minimal or no breaking changes, additional fields can be added in the candidate descriptor until the reserved space is exhausted
 
-Once the reserved space is exhausted, versioning will be implemented. The candidate receipt format will be versioned. This will exteend to pvf execution which requires versioning for the validation function, inputs and outputs (`CandidateCommitments`).
+Once the reserved space is exhausted, versioning will be implemented. The candidate receipt format will be versioned. Versioning should also be implemented for the validation function, inputs and outputs (`CandidateCommitments`).

--- a/text/0103-introduce-core-index-commitment.md
+++ b/text/0103-introduce-core-index-commitment.md
@@ -195,7 +195,6 @@ It is mandatory for elastic parachains to switch to the new receipt format. It i
 switch to the new receipts for providing the session index for disputes.
 
 The implementation of this RFC itself must not introduce any breaking changes for the parachain runtime or collator nodes.
-Collator must compute the core index from the 
 
 ## Compatibility
 

--- a/text/0103-introduce-core-index-commitment.md
+++ b/text/0103-introduce-core-index-commitment.md
@@ -2,34 +2,33 @@
 
 |                 |                                                                                             |
 | --------------- | ------------------------------------------------------------------------------------------- |
-| **Start Date**  | 15 July 2024                                                                    |
+| **Start Date** | 15 July 2024                                                                    |
 | **Description** | Constrain parachain block validity to a specific core and session                                                                 |
-| **Authors**     | Andrei Sandu                                                                                            |
+| **Authors** | Andrei Sandu                                                                                            |
 
 ## Summary
 
 Elastic scaling is not resilient against griefing attacks without a way for a PoV (Proof of Validity)
-to commit to the particular core index it was intended for. This RFC proposes a way to include 
-core index information in the candidate commitments and the `CandidateDescriptor` data structure 
-in a backwards compatible way. Additionally it proposes the addition of a `SessionIndex` field in 
-the `CandidateDescriptor` to make dispute resolution more secure and robust. 
-
+to commit to the particular core index it was intended for. This RFC proposes a way to include
+core index information in the candidate commitments and the `CandidateDescriptor` data structure
+in a backward compatible way. Additionally, it proposes the addition of a `SessionIndex` field in
+the `CandidateDescriptor` to make dispute resolution more secure and robust.
 
 ## Motivation
 
 This RFC proposes a way to solve two different problems:
 
-1. For Elastic Scaling, it prevents anyone who has acquired a valid collation to DoS the parachain 
-   by providing the same collation to all backing groups assigned to the parachain. This can 
-   happen before the next valid parachain block is authored and will prevent the chain of 
-   candidates to be formed, reducing the throughput of the parachain to a single core.
-2. The dispute protocol relies on validators trusting the session index provided by other 
-   validators when initiating and participating in disputes. It is used to lookup validator keys 
-   and check dispute vote signatures. By adding a `SessionIndex` in the `CandidateDescriptor`, 
-   validators no longer have to trust the `Sessionindex` provided by the validator raising a 
-   dispute. It can happen that the dispute concerns a relay chain block not yet imported by a 
-   validator. In this case validators can safely assume the session index refers to the session 
-   the candidate has appeared in, otherwise the chain would have rejected candidate.
+1. For Elastic Scaling, it prevents anyone who has acquired a valid collation to DoS the parachain
+ by providing the same collation to all backing groups assigned to the parachain. This can
+ happen before the next valid parachain block is authored and will prevent the chain of
+ candidates from being formed, reducing the throughput of the parachain to a single core.
+2. The dispute protocol relies on validators trusting the session index provided by other
+ validators when initiating and participating in disputes. It is used to look up validator keys
+ and check dispute vote signatures. By adding a `SessionIndex` in the `CandidateDescriptor`,
+ validators no longer have to trust the `Sessionindex` provided by the validator raising a
+ dispute. The dispute may concern a relay chain block not yet imported by a
+ validator. In this case, validators can safely assume the session index refers to the session
+ the candidate has appeared in, otherwise, the chain would have rejected the candidate.
 
 ## Stakeholders
 
@@ -41,41 +40,42 @@ This approach and alternatives have been considered and discussed in [this issue
 
 ## Explanation
 
-The approach proposed below was chosen primarily because it minimizes the number of breaking 
-changes, the complexity and takes less implementation and testing time. The proposal is to change 
-the existing primitives while keeping binary compatibility with the older versions. We repurpose 
-unused fields to introduce core index and a session index information in the `CandidateDescriptor` 
-and extend the UMP for transporting non-XCM messages. 
+The approach proposed below was chosen primarily because it minimizes the number of breaking
+changes, the complexity and takes less implementation and testing time. The proposal is to change
+the existing primitives while keeping binary compatibility with the older versions. We repurpose
+unused fields to introduce core index and a session index information in the `CandidateDescriptor`
+and extend the UMP to transport non-XCM messages.
 
 ### Reclaiming unused space in the descriptor
 
-The `CandidateDescriptor` currently includes `collator` and `signature` fields. The collator 
-includes a signature on the following descriptor fields: parachain id, relay parent, validation 
-data hash, validation code hash and the PoV hash.
+The `CandidateDescriptor` includes `collator` and `signature` fields. The collator
+includes a signature on the following descriptor fields: parachain id, relay parent, validation
+data hash, validation code hash, and the PoV hash.
 
-However, in practice, having a collator signature in the receipt on the relay chain does not 
-provide any benefits as there is no mechanism to punish or reward collators that have provided 
+However, in practice, having a collator signature in the receipt on the relay chain does not
+provide any benefits as there is no mechanism to punish or reward collators that have provided
 bad parachain blocks.
 
-This proposal aims to remove the collator signature and all the logic that checks the collator 
-signatures of candidate receipts. We use the first 7 reclaimed bytes to represent version, 
-the core and session index, and fill the rest with zeroes. So, there is no change in the layout 
-and length of the receipt. The new primitive is binary compatible with the old one.
+This proposal aims to remove the collator signature and all the logic that checks the collator
+signatures of candidate receipts. We use the first 7 reclaimed bytes to represent the version,
+the core,  session index, and fill the rest with zeroes. So, there is no change in the layout
+and length of the receipt. The new primitive is binary-compatible with the old one.
 
 ### UMP transport
 
-[CandidateCommitments](https://github.com/paritytech/polkadot-sdk/blob/b5029eb4fd6c7ffd8164b2fe12b71bad0c59c9f2/polkadot/primitives/src/v7/mod.rs#L682) 
-remains unchanged as we will store scale encoded `UMPSignal` messages directly in the parachain 
-UMP queue by outputing them in [upward_messages](https://github.com/paritytech/polkadot-sdk/blob/b5029eb4fd6c7ffd8164b2fe12b71bad0c59c9f2/polkadot/primitives/src/v7/mod.rs#L684). 
+[CandidateCommitments](https://github.com/paritytech/polkadot-sdk/blob/b5029eb4fd6c7ffd8164b2fe12b71bad0c59c9f2/polkadot/primitives/src/v7/mod.rs#L682)
+remains unchanged as we will store scale encoded `UMPSignal` messages directly in the parachain
+UMP queue by outputting them in [upward_messages](https://github.com/paritytech/polkadot-sdk/blob/b5029eb4fd6c7ffd8164b2fe12b71bad0c59c9f2/polkadot/primitives/src/v7/mod.rs#L684).
 
-The UMP queue layout is changed to allow the relay chain to receive both the XCM messages and 
-`UMPSignal` messages. An empty message (empty `Vec<u8>`) is used to mark the end XCM messages and 
+The UMP queue layout is changed to allow the relay chain to receive both the XCM messages and
+`UMPSignal` messages. An empty message (empty `Vec<u8>`) is used to mark the end of XCM messages and
 the start of `UMPSignal` messages.
 
-This way of representing the new messages has been chosen over introducing an enum wrapper to 
-minimize breaking changes of XCM message decoding in tools like Subscan for example. 
+This way of representing the new messages has been chosen over introducing an enum wrapper to
+minimize breaking changes of XCM message decoding in tools like Subscan for example.
 
-Example: 
+Example:
+
 ```rust
 [ XCM message1, XCM message2, ..., EMPTY message, UMPSignal::SelectCore ]
 ```
@@ -83,7 +83,7 @@ Example:
 #### `UMPSignal` messages
 
 ```rust
-/// An `u8` wrap around sequence number. Typically this would be the least significant byte of the 
+/// An `u8` wrap-around sequence number. Typically this would be the least significant byte of the 
 /// parachain block number.
 pub struct CoreSelector(pub u8);
 
@@ -92,17 +92,17 @@ pub struct ClaimQueueOffset(pub u8);
 
 /// Signals sent by a parachain to the relay chain.
 pub enum UMPSignal {
-	/// A message sent by a parachain to select the core the candidate is committed to.
-	/// Relay chain validators, in particular backers, use the `CoreSelector` and `ClaimQueueOffset`
-	/// to compute the index of the core the candidate has committed to.
-	///
-	SelectCore(CoreSelector, ClaimQueueOffset),
+    /// A message sent by a parachain to select the core the candidate is committed to.
+    /// Relay chain validators, in particular backers, use the `CoreSelector` and `ClaimQueueOffset`
+    /// to compute the index of the core the candidate has committed to.
+    ///
+    SelectCore(CoreSelector, ClaimQueueOffset),
 }
 ```
 
-The parachain runtime is not concerned with the actual `CoreIndex` the candidate is intended for, 
-but must provide enough information for the validators and collators to compute it. `CoreSelector` 
-and `ClaimQueueOffset` use only 2 bytes and fulfill the requirement.
+The parachain runtime is not concerned with the actual `CoreIndex` the candidate is intended for,
+but must provide enough information for the validators and collators to compute it. `CoreSelector`
+and `ClaimQueueOffset` use only 2 bytes and fulfills the requirement.
 
 **Example:**
 
@@ -111,13 +111,13 @@ and `ClaimQueueOffset` use only 2 bytes and fulfill the requirement.
 The table below represents a snapshot of the claim queue:
 
 |  | offset = 0 | offset = 1 | offset = 2 |
-| :--:	 | :--:   | :--:   | :--:   |
-| Core 1    | **Para A**     | **Para A**     | **Para A**     |
-| Core 2   | **Para A**  | Para B  | **Para A**  |
-| Core 3   | Para B  | **Para A**  | **Para A** |
+| :--:   | :--:   | :--:   | :--:   |
+| Core 1    | **Para A** | **Para A** | **Para A** |
+| Core 2   | **Para A** | Para B  | **Para A** |
+| Core 3   | Para B  | **Para A** | **Para A** |
 
-The purpose of `ClaimQueueOffset` is to select the column from the above table. 
-For `cq_offset = 1` we get `[ Para A, Para B, Para A]` and use as input to create 
+The purpose of `ClaimQueueOffset` is to select the column from the above table.
+For `cq_offset = 1` we get `[ Para A, Para B, Para A]` and use as input to create
 a sorted vec with the cores A is assigned to: `[ Core 1, Core 3]` and call it `para_assigned_cores`.
 We use `core_selector` and determine the committed core index is `Core 3` like this:
 
@@ -125,106 +125,105 @@ We use `core_selector` and determine the committed core index is `Core 3` like t
 let committed_core_index = para_assigned_cores[core_selector % para_assigned_cores.len()];
 ```
 
-Parachains should prefer to have a static `ClaimQueueOffset` value that makes sense for their 
+Parachains should prefer to have a static `ClaimQueueOffset` value that makes sense for their
 usecase which can be changed by governance at some future point.
 
 ### Polkadot Primitive changes
 
 #### New [CandidateDescriptor](https://github.com/paritytech/polkadot-sdk/blob/b5029eb4fd6c7ffd8164b2fe12b71bad0c59c9f2/polkadot/primitives/src/v7/mod.rs#L512)
 
-- reclaim 32 bytes from `collator: CollatorId` and 64 bytes from `signature: CollatorSignature` 
-  and rename to `reserved1`  and `reserved2` fields.
+- reclaim 32 bytes from `collator: CollatorId` and 64 bytes from `signature: CollatorSignature`
+ and rename to `reserved1` and `reserved2` fields.
 - take 1 bytes from `reserved1` for a new `version: u8` field.
 - take 2 bytes from `reserved1` for a new `core_index: u16` field.
 - take 4 bytes from `reserved1` for a new `session_index: u32` field.
 - the remaining `reserved1` and `reserved2` fields are zeroed
 
-Thew new primitive will look like this:
+The new primitive will look like this:
 
 ```rust
 pub struct CandidateDescriptorV2<H = Hash> {
-	/// The ID of the para this is a candidate for.
-	para_id: ParaId,
-	/// The hash of the relay-chain block this is executed in the context of.
-	relay_parent: H,
-	/// Version field. The raw value here is not exposed, instead it is used
-	/// to determine the `CandidateDescriptorVersion`
-	version: InternalVersion,
-	/// The core index where the candidate is backed.
-	core_index: u16,
-	/// The session in which the candidate is backed.
-	session_index: SessionIndex,
-	/// Reserved bytes.
-	reserved1: [u8; 25],
-	/// The blake2-256 hash of the persisted validation data. This is extra data derived from
-	/// relay-chain state which may vary based on bitfields included before the candidate.
-	/// Thus it cannot be derived entirely from the relay-parent.
-	persisted_validation_data_hash: Hash,
-	/// The blake2-256 hash of the PoV.
-	pov_hash: Hash,
-	/// The root of a block's erasure encoding Merkle tree.
-	erasure_root: Hash,
-	/// Reserved bytes.
-	reserved2: [u8; 64],
-	/// Hash of the para header that is being generated by this candidate.
-	para_head: Hash,
-	/// The blake2-256 hash of the validation code bytes.
-	validation_code_hash: ValidationCodeHash,
+    /// The ID of the para this is a candidate for.
+    para_id: ParaId,
+    /// The hash of the relay-chain block this is executed in the context of.
+    relay_parent: H,
+    /// Version field. The raw value here is not exposed, instead, it is used
+    /// to determine the `CandidateDescriptorVersion`
+    version: InternalVersion,
+    /// The core index where the candidate is backed.
+    core_index: u16,
+    /// The session in which the candidate is backed.
+    session_index: SessionIndex,
+    /// Reserved bytes.
+    reserved1: [u8; 25],
+    /// The blake2-256 hash of the persisted validation data. This is extra data derived from
+    /// relay-chain state which may vary based on bitfields included before the candidate.
+    /// Thus it cannot be derived entirely from the relay parent.
+    persisted_validation_data_hash: Hash,
+    /// The blake2-256 hash of the PoV.
+    pov_hash: Hash,
+    /// The root of a block's erasure encoding Merkle tree.
+    erasure_root: Hash,
+    /// Reserved bytes.
+    reserved2: [u8; 64],
+    /// Hash of the para header that is being generated by this candidate.
+    para_head: Hash,
+    /// The blake2-256 hash of the validation code bytes.
+    validation_code_hash: ValidationCodeHash,
 }
 ```
 
-In future format versions, parts of the `reserved1` and `reserved2` bytes can be used to include 
+In future format versions, parts of the `reserved1` and `reserved2` bytes can be used to include
 additional information in the descriptor.
 
 ### Parachain block validation
 
 If the candidate descriptor is version 1, there are no changes.
 
-Backers must check the validity of `core_index` and `session_index` fields. 
+Backers must check the validity of `core_index` and `session_index` fields.
 A candidate must not be backed if any of the following are true:
+
 - the `core_index` in the descriptor does not match the core the backer is assigned to
 - the `session_index` is not equal to the session index the candidate is backed in
-- the `core_index` in the descriptor does not match the one determined by the 
+- the `core_index` in the descriptor does not match the one determined by the
   `UMPSignal::SelectCore` message
-
 
 ### On-chain backing
 
 If the candidate descriptor is version 1, there are no changes.
 
-For version 2 descriptors the runtime will determine the `core_index` using the same inputs 
-as backers did off-chain. It currently stores the claim queue at the newest allowed 
-relay parent corresponding to claim queue offset `0`. The runtime needs to be changed to store
+For version 2 descriptors the runtime will determine the `core_index` using the same inputs
+as backers did off-chain. It currently stores the claim queue at the newest allowed
+relay parent corresponding to the claim queue offset `0`. The runtime needs to be changed to store
 a claim queue snapshot at all allowed relay parents.
-
 
 ### Backwards compatibility
 
-There are two flavors of candidate receipts that are used in network protocols, runtime and node 
+Two flavors of candidate receipts are used in network protocols, runtime and node
 implementation:
-- `CommittedCandidateReceipt` which includes the `CandidateDescriptor` and the `CandidateCommitments` 
+
+- `CommittedCandidateReceipt` which includes the `CandidateDescriptor` and the `CandidateCommitments`
 - `CandidateReceipt` which includes the `CandidateDescriptor` and just a hash of the commitments
 
-We want to support both the old and new versions in the runtime and node, so the implementation must 
+We want to support both the old and new versions in the runtime and node, so the implementation must
 be able to detect the version of a given candidate receipt.
 
 The version of the descriptor is detected by checking the reserved fields.
-If they are not zerored, it means it is a version 1 descriptor. Otherwise the `version` field
-is used further to determine the version. It should be `0` for version 2 descriptors. If it is not 
+If they are not zeroed, it means it is a version 1 descriptor. Otherwise the `version` field
+is used further to determine the version. It should be `0` for version 2 descriptors. If it is not
 the descriptor has an unknown version and should be considered invalid.
-
 
 ## Drawbacks
 
-The only drawback is that further additions to the descriptor are limited to the amount of 
+The only drawback is that further additions to the descriptor are limited to the amount of
 remaining unused space.
 
 ## Testing, Security, and Privacy
 
-Standard testing (unit tests, CI zombienet tests) for functionality and mandatory security audit 
+Standard testing (unit tests, CI zombienet tests) for functionality and mandatory security audit
 to ensure the implementation does not introduce any new security issues.
 
-Backwards compatibility of the implementation will be tested on testnets (Versi and Westend).
+Backward compatibility of the implementation will be tested on testnets (Versi and Westend).
 
 There is no impact on privacy.
 
@@ -233,59 +232,58 @@ There is no impact on privacy.
 Overall performance will be improved by not checking the collator signatures in runtime and nodes.
 The impact on the UMP queue and candidate receipt processing is negligible.
 
-The `ClaimQueueOffset` along with the relay parent choice allows parachains to optimize their 
-block production for either throughput or latency. A value of `0` with newest relay parent 
-provides best latency while picking older relay parents avoids re-orgs.
-
+The `ClaimQueueOffset` along with the relay parent choice allows parachains to optimize their
+block production for either throughput or latency. A value of `0` with the newest relay parent
+provides the best latency while picking older relay parents avoids re-orgs.
 
 ## Ergonomics
 
-It is mandatory for elastic parachains to switch to the new receipt format. It is optional but 
-desired that all parachains switch to the new receipts for providing the session index for 
+It is mandatory for elastic parachains to switch to the new receipt format. It is optional but
+desired that all parachains switch to the new receipts for providing the session index for
 disputes.
 
-The implementation of this RFC itself must not introduce any breaking changes for the parachain 
+The implementation of this RFC itself must not introduce any breaking changes for the parachain
 runtime or collator nodes.
 
 ## Compatibility
 
-The proposed changes are backwards compatible in general, but additional care must be taken by 
-waiting for at least `2/3 + 1` validators to upgrade. Validators that have not upgraded will not 
-back candidates using the new descriptor format and will also initiate disputes against these 
+The proposed changes are backward compatible in general, but additional care must be taken by
+waiting for at least `2/3 + 1` validators to upgrade. Validators that have not upgraded will not
+back candidates using the new descriptor format and will also initiate disputes against these
 candidates.
 
 ### Relay chain runtime
 
-The first step is to remove collator signature checking logic in the runtime, but keep the node 
-side collator signature checks. 
+The first step is to remove collator signature checking logic in the runtime but keep the node
+side collator signature checks.
 
-The runtime must be upgraded to support the new primitives before any collator or node is allowed 
-to use the new candidate receipts format. 
+The runtime must be upgraded to support the new primitives before any collator or node is allowed
+to use the new candidate receipts format.
 
 ### Validators
 
 To ensure a smooth launch, a new node feature is required.
-The feature acts as a signal for supporting the new candidate receipts on the node side and can 
-only be safely enabled if at least `2/3 + 1` of the validators are upgraded. Node implementions 
-need to decode the new candidate descriptor once the feature is enabled otherwise they might 
+The feature acts as a signal for supporting the new candidate receipts on the node side and can
+only be safely enabled if at least `2/3 + 1` of the validators are upgraded. Node implementations
+need to decode the new candidate descriptor once the feature is enabled otherwise they might
 raise disputes and get slashed.
 
-Once the feature is enabled, the validators will skip checking the collator signature when 
-processing the candidate receipts and verify the `CoreIndex` and `SessionIndex` fields if 
+Once the feature is enabled, the validators will skip checking the collator signature when
+processing the candidate receipts and verify the `CoreIndex` and `SessionIndex` fields if
 present in the receipt.
 
 No new implementation of networking protocol versions for collation and validation is required.
 
 ### Tooling
 
-Any tooling that decodes UMP XCM messages needs an update to support or ignore the new UMP 
-messages, but they should be fine to decode the regular XCM messages that come before the 
+Any tooling that decodes UMP XCM messages needs an update to support or ignore the new UMP
+messages, but they should be fine to decode the regular XCM messages that come before the
 separator.
 
 ## Prior Art and References
 
 Forum discussion about a new `CandidateReceipt` format:
- https://forum.polkadot.network/t/pre-rfc-discussion-candidate-receipt-format-v2/3738
+ <https://forum.polkadot.network/t/pre-rfc-discussion-candidate-receipt-format-v2/3738>
 
 ## Unresolved Questions
 
@@ -293,10 +291,10 @@ N/A
 
 ## Future Directions and Related Material
 
-The implementation is extensible and future proof to some extent. With minimal or no breaking 
-changes, additional fields can be added in the candidate descriptor until the reserved space is 
+The implementation is extensible and future-proof to some extent. With minimal or no breaking
+changes, additional fields can be added in the candidate descriptor until the reserved space is
 exhausted
 
-At this point there is a simple way to determine the version of the receipt, by testing for zeroed 
-reserved bytes in the descriptor. Future versions of the receipt can be implemented and identified 
-by using the `version` field of the descirptor introduced in this RFC.
+At this point, there is a simple way to determine the version of the receipt, by testing for zeroed
+reserved bytes in the descriptor. Future versions of the receipt can be implemented and identified
+by using the `version` field of the descriptor introduced in this RFC.

--- a/text/0103-introduce-core-index-commitment.md
+++ b/text/0103-introduce-core-index-commitment.md
@@ -232,8 +232,9 @@ Overall performance will be improved by not checking the collator signatures in 
 The impact on the UMP queue and candidate receipt processing is negligible.
 
 The `ClaimQueueOffset` along with the relay parent choice allows parachains to optimize their
-block production for either throughput or latency. A value of `0` with the newest relay parent
-provides the best latency while picking older relay parents avoids re-orgs.
+block production for either throughput or lower XCM message processing latency. A value of `0`
+with the newest relay parent provides the best latency while picking older relay parents avoids
+re-orgs.
 
 ## Ergonomics
 

--- a/text/0103-introduce-core-index-commitment.md
+++ b/text/0103-introduce-core-index-commitment.md
@@ -103,7 +103,6 @@ can be a friction point. It will work out fine to decrease the value to build mo
 present. But if the value is increased to build more into the future, a relay chain block will 
 be skipped.
 
-
 ### Polkadot Primitive changes
 
 #### New [CandidateDescriptor](https://github.com/paritytech/polkadot-sdk/blob/b5029eb4fd6c7ffd8164b2fe12b71bad0c59c9f2/polkadot/primitives/src/v7/mod.rs#L512)
@@ -188,6 +187,11 @@ There is no impact on privacy.
 ## Performance
 
 The expectation is that performance impact is negligible for sending and processing the UMP message has negligible performance impact in the runtime as well as on the node side.
+
+The `ClaimQueueOffset` along with the relay parent choice allows parachains to optimize their block production
+for either throughput or latency. A value of `0` with newest relay parent provides best latency while picking
+older relay parents avoids re-orgs.
+
 
 ## Ergonomics
 

--- a/text/0103-introduce-core-index-commitment.md
+++ b/text/0103-introduce-core-index-commitment.md
@@ -3,7 +3,7 @@
 |                 |                                                                                             |
 | --------------- | ------------------------------------------------------------------------------------------- |
 | **Start Date**  | 15 July 2024                                                                    |
-| **Description** | Constrain parachain block validity on a single core                                                                   |
+| **Description** | Constrain parachain block validity on a specific core                                                                   |
 | **Authors**     | Andrei Sandu                                                                                            |
 
 ## Summary

--- a/text/0103-introduce-core-index-commitment.md
+++ b/text/0103-introduce-core-index-commitment.md
@@ -168,12 +168,13 @@ Parachain that use elastic scaling must send the separator empty message followe
 
 ## Compatibility
 
-To ensure a smooth transition the first step is to remove collator signature checking logic on the node side and upgrade validators. Any tooling that uses these fields will require similar changes as described above to support both formats.
+To ensure a smooth transition the first step is to remove collator signature checking logic in the runtime and the node side, then upgrade validators. Any tooling that decodes UMP XCM messages needs an update to support the new UMP messages.
 
-The runtime does not check the collator signature so there are no other specific concers for compatibility except adding the support for the new primitives.
+`CoreIndex` commitments are needed only by parachains using elastic scaling. Just upgrading the collator node and runtime should be sufficient and possible with no manual changes.
 
+No new implementation of networking protocol versions for collation and validation are required.
 
-`CoreIndex` commitments are mandatory only for parachains using elastic scaling. No new implementation of networking protocol versions for collation and validation are required.
+The runtime does check the collator signature in inclusion, so that should be removed as first step, before the new receipts are introduced. 
 
 
 ## Prior Art and References

--- a/text/0103-introduce-core-index-commitment.md
+++ b/text/0103-introduce-core-index-commitment.md
@@ -8,15 +8,28 @@
 
 ## Summary
 
-Elastic scaling is not resilient against griefing attacks without a way for a PoV (Proof of Validity) to commit to the particular core index it was intended for. This RFC proposes a way to include core index information in the candidate commitments and the `CandidateDescriptor` data structure in a backwards compatible way. Additionally it proposes the addition of a `SessionIndex` field in the `CandidateDescriptor` to make dispute resolution more secure and robust. 
+Elastic scaling is not resilient against griefing attacks without a way for a PoV (Proof of Validity)
+to commit to the particular core index it was intended for. This RFC proposes a way to include 
+core index information in the candidate commitments and the `CandidateDescriptor` data structure 
+in a backwards compatible way. Additionally it proposes the addition of a `SessionIndex` field in 
+the `CandidateDescriptor` to make dispute resolution more secure and robust. 
 
 
 ## Motivation
 
 This RFC proposes a way to solve two different problems:
 
-1. For Elastic Scaling, it prevents anyone who has acquired a valid collation to DoS the parachain by providing the same collation to all backing groups assigned to the parachain. This can happen before the next valid parachain block is authored and will prevent the chain of candidates to be formed, reducing the throughput of the parachain to a single core.
-2. The dispute protocol relies on validators trusting the session index provided by other valdiators when initiating and participating in disputes. It is used to lookup validator keys and check dispute vote signatures. By adding a `SessionIndex` in the `CandidateDescriptor`, validators no longer have to trust the `Sessionindex` provided by the validator raising a dispute. It can happen that the dispute concerns a relay chain block not yet imported by a validator. In this case validators can safely assume the session index refers to the session the candidate has appeared in, otherwise the chain would have rejected candidate.
+1. For Elastic Scaling, it prevents anyone who has acquired a valid collation to DoS the parachain 
+   by providing the same collation to all backing groups assigned to the parachain. This can 
+   happen before the next valid parachain block is authored and will prevent the chain of 
+   candidates to be formed, reducing the throughput of the parachain to a single core.
+2. The dispute protocol relies on validators trusting the session index provided by other 
+   validators when initiating and participating in disputes. It is used to lookup validator keys 
+   and check dispute vote signatures. By adding a `SessionIndex` in the `CandidateDescriptor`, 
+   validators no longer have to trust the `Sessionindex` provided by the validator raising a 
+   dispute. It can happen that the dispute concerns a relay chain block not yet imported by a 
+   validator. In this case validators can safely assume the session index refers to the session 
+   the candidate has appeared in, otherwise the chain would have rejected candidate.
 
 ## Stakeholders
 
@@ -28,23 +41,39 @@ This approach and alternatives have been considered and discussed in [this issue
 
 ## Explanation
 
-The approach proposed below was chosen primarly because it minimizes the number of breaking changes, the complexity and takes less implementation and testing time. The proposal is to change the existing primitives while keeping binary compatibility with the older versions. We repurpose unused fields to introduce core index and a session index information in the `CandidateDescriptor` and extend the UMP for transporting non-XCM messages. 
+The approach proposed below was chosen primarily because it minimizes the number of breaking 
+changes, the complexity and takes less implementation and testing time. The proposal is to change 
+the existing primitives while keeping binary compatibility with the older versions. We repurpose 
+unused fields to introduce core index and a session index information in the `CandidateDescriptor` 
+and extend the UMP for transporting non-XCM messages. 
 
 ### Reclaiming unused space in the descriptor
 
-The `CandidateDescriptor` currently includes `collator` and `signature` fields. The collator includes a signature on the following descriptor fields: parachain id, relay parent, validation data hash, validation code hash and the PoV hash.
+The `CandidateDescriptor` currently includes `collator` and `signature` fields. The collator 
+includes a signature on the following descriptor fields: parachain id, relay parent, validation 
+data hash, validation code hash and the PoV hash.
 
-However, in practice, having a collator signature in the receipt on the relay chain does not provide any benefits as there is no mechanism to punish or reward collators that have provided bad parachain blocks.
+However, in practice, having a collator signature in the receipt on the relay chain does not 
+provide any benefits as there is no mechanism to punish or reward collators that have provided 
+bad parachain blocks.
 
-This proposal aims to remove the collator signature and all the logic that checks the collator signatures of candidate receipts. We use the first 7 reclaimed bytes to represent version, the core and session index, and fill the rest with zeroes. So, there is no change in the layout and length of the receipt. The new primitive is binary compatible with the old one.
+This proposal aims to remove the collator signature and all the logic that checks the collator 
+signatures of candidate receipts. We use the first 7 reclaimed bytes to represent version, 
+the core and session index, and fill the rest with zeroes. So, there is no change in the layout 
+and length of the receipt. The new primitive is binary compatible with the old one.
 
 ### UMP transport
 
-[CandidateCommitments](https://github.com/paritytech/polkadot-sdk/blob/b5029eb4fd6c7ffd8164b2fe12b71bad0c59c9f2/polkadot/primitives/src/v7/mod.rs#L682) remains unchanged as we will store scale encoded `UMPSignal` messages directly in the parachain UMP queue by outputing them in [upward_messages](https://github.com/paritytech/polkadot-sdk/blob/b5029eb4fd6c7ffd8164b2fe12b71bad0c59c9f2/polkadot/primitives/src/v7/mod.rs#L684). 
+[CandidateCommitments](https://github.com/paritytech/polkadot-sdk/blob/b5029eb4fd6c7ffd8164b2fe12b71bad0c59c9f2/polkadot/primitives/src/v7/mod.rs#L682) 
+remains unchanged as we will store scale encoded `UMPSignal` messages directly in the parachain 
+UMP queue by outputing them in [upward_messages](https://github.com/paritytech/polkadot-sdk/blob/b5029eb4fd6c7ffd8164b2fe12b71bad0c59c9f2/polkadot/primitives/src/v7/mod.rs#L684). 
 
-The UMP queue layout is changed to allow the relay chain to receive both the XCM messages and `UMPSignal` messages. An empty message (empty `Vec<u8>`) is used to mark the end XCM messages and the start of `UMPSignal` messages.
+The UMP queue layout is changed to allow the relay chain to receive both the XCM messages and 
+`UMPSignal` messages. An empty message (empty `Vec<u8>`) is used to mark the end XCM messages and 
+the start of `UMPSignal` messages.
 
-This way of representing the new messages has been chosen over introducing an enum wrapper to minimize breaking changes of XCM message decoding in tools like Subscan for example. 
+This way of representing the new messages has been chosen over introducing an enum wrapper to 
+minimize breaking changes of XCM message decoding in tools like Subscan for example. 
 
 Example: 
 ```rust
@@ -54,19 +83,18 @@ Example:
 #### `UMPSignal` messages
 
 ```rust
-/// An `u8` wrap around sequence number. Typically this would be the least significant byte of the parachain block number.
+/// An `u8` wrap around sequence number. Typically this would be the least significant byte of the 
+/// parachain block number.
 pub struct CoreSelector(pub u8);
 
 /// An offset in the relay chain claim queue.
 pub struct ClaimQueueOffset(pub u8);
 
-/// Default claim queue offset
-pub const DEFAULT_CLAIM_QUEUE_OFFSET: ClaimQueueOffset = ClaimQueueOffset(1);
-
+/// Signals sent by a parachain to the relay chain.
 pub enum UMPSignal {
-	/// A message sent by a parachain to select the core the candidate is commited to.
+	/// A message sent by a parachain to select the core the candidate is committed to.
 	/// Relay chain validators, in particular backers, use the `CoreSelector` and `ClaimQueueOffset`
-	/// to compute the index of the core the candidate has commited to.
+	/// to compute the index of the core the candidate has committed to.
 	///
 	SelectCore(CoreSelector, ClaimQueueOffset),
 }
@@ -74,7 +102,7 @@ pub enum UMPSignal {
 
 The parachain runtime is not concerned with the actual `CoreIndex` the candidate is intended for, 
 but must provide enough information for the validators and collators to compute it. `CoreSelector` 
-and `ClaimQueueOffset` use only 2 bytes and fullfil the requirement.
+and `ClaimQueueOffset` use only 2 bytes and fulfill the requirement.
 
 **Example:**
 
@@ -91,7 +119,7 @@ The table below represents a snapshot of the claim queue:
 The purpose of `ClaimQueueOffset` is to select the column from the above table. 
 For `cq_offset = 1` we get `[ Para A, Para B, Para A]` and use as input to create 
 a sorted vec with the cores A is assigned to: `[ Core 1, Core 3]` and call it `para_assigned_cores`.
-We use `core_selector` and determine the commited core index is `Core 3` like this:
+We use `core_selector` and determine the committed core index is `Core 3` like this:
 
 ```rust
 let committed_core_index = para_assigned_cores[core_selector % para_assigned_cores.len()];
@@ -107,7 +135,8 @@ be skipped.
 
 #### New [CandidateDescriptor](https://github.com/paritytech/polkadot-sdk/blob/b5029eb4fd6c7ffd8164b2fe12b71bad0c59c9f2/polkadot/primitives/src/v7/mod.rs#L512)
 
-- reclaim 32 bytes from `collator: CollatorId` and 64 bytes from `signature: CollatorSignature` and rename to `reserved1`  and `reserved2` fields.
+- reclaim 32 bytes from `collator: CollatorId` and 64 bytes from `signature: CollatorSignature` 
+  and rename to `reserved1`  and `reserved2` fields.
 - take 1 bytes from `reserved1` for a new `version: u8` field.
 - take 2 bytes from `reserved1` for a new `core_index: u16` field.
 - take 4 bytes from `reserved1` for a new `session_index: u32` field.
@@ -147,7 +176,8 @@ pub struct CandidateDescriptorV2<H = Hash> {
 }
 ```
 
-In future format versions, parts of the `reserved1` and `reserved2` bytes can be used to include additional information in the descriptor.
+In future format versions, parts of the `reserved1` and `reserved2` bytes can be used to include 
+additional information in the descriptor.
 
 ### Parachain block validation
 
@@ -157,28 +187,32 @@ For version 2, backers and the runtime must check the validity of `core_index` a
 A candidate must not be backed if any of the following are true:
 - the `core_index` in the descriptor does not match the core the backing group is assigned to
 - the `session_index` is not equal to the session of the `relay_parent` in the descriptor
-- the `core_index` in descriptor does not match the one determined by the `UMPSignal::SelectCore` message
+- the `core_index` in the descriptor does not match the one determined by the `UMPSignal::SelectCore` message
 
 
 ### Backwards compatibility
 
-There are two flavors of candidate receipts which are used in network protocols, runtime and node implementation:
+There are two flavors of candidate receipts that are used in network protocols, runtime and node 
+implementation:
 - `CommittedCandidateReceipt` which includes the `CanidateDescriptor` and the `CandidateCommitments` 
 - `CandidateReceipt` which includes the `CanidateDescriptor` and just a hash of the commitments
 
-We want to support both the old and new versions in the runtime and node. The implementation must be able to detect the version of a given candidate receipt.
+We want to support both the old and new versions in the runtime and node. The implementation must 
+be able to detect the version of a given candidate receipt.
 
 The version of the descriptor is detected by checking if the `version` field is `0` and the 
-reserved fields are zerored. If this is true it means the descriptor is version 2, 
+reserved fields are zeroed. If this is true it means the descriptor is version 2, 
 otherwise we consider it is version 1.
 
 ## Drawbacks
 
-The only drawback is that further additions to the descriptor are limited to the amount of remaining unused space.
+The only drawback is that further additions to the descriptor are limited to the amount of 
+remaining unused space.
 
 ## Testing, Security, and Privacy
 
-Standard testing (unit tests, CI zombienet tests) for functionality and mandatory secuirty audit to ensure the implementation does not introduce any new security issues.
+Standard testing (unit tests, CI zombienet tests) for functionality and mandatory security audit 
+to ensure the implementation does not introduce any new security issues.
 
 Backwards compatibility of the implementation will be tested on testnets (Versi and Westend).
 
@@ -186,51 +220,59 @@ There is no impact on privacy.
 
 ## Performance
 
-The expectation is that performance impact is negligible for sending and processing the UMP message has negligible performance impact in the runtime as well as on the node side.
+The expected performance impact is negligible for sending and processing the new UMP 
+message in the runtime as well as on the node side.
 
-The `ClaimQueueOffset` along with the relay parent choice allows parachains to optimize their block production
-for either throughput or latency. A value of `0` with newest relay parent provides best latency while picking
-older relay parents avoids re-orgs.
+The `ClaimQueueOffset` along with the relay parent choice allows parachains to optimize their 
+block production for either throughput or latency. A value of `0` with newest relay parent 
+provides best latency while picking older relay parents avoids re-orgs.
 
 
 ## Ergonomics
 
-It is mandatory for elastic parachains to switch to the new receipt format. It is optional but desired that all parachains
-switch to the new receipts for providing the session index for disputes.
+It is mandatory for elastic parachains to switch to the new receipt format. It is optional but 
+desired that all parachains switch to the new receipts for providing the session index for 
+disputes.
 
-The implementation of this RFC itself must not introduce any breaking changes for the parachain runtime or collator nodes.
+The implementation of this RFC itself must not introduce any breaking changes for the parachain 
+runtime or collator nodes.
 
 ## Compatibility
 
-The proposed changes are backwards compatible in general, but additional care must be taken by waiting for at least `2/3 + 1` validators to upgrade. Validators that have not upgraded will not back candidates using the new descriptor format and will also initiate disputes against.
+The proposed changes are backwards compatible in general, but additional care must be taken by 
+waiting for at least `2/3 + 1` validators to upgrade. Validators that have not upgraded will not 
+back candidates using the new descriptor format and will also initiate disputes against.
 
 ### Relay chain runtime
 
-The first step is to remove collator signature checking logic in the runtime, but keep the node side collator signature 
+The first step is to remove collator signature checking logic in the runtime, but keep the node 
+side collator signature 
 checks. 
 
-The runtime must be upgraded to the new primitives before any collator or node are allowed to use the new candidate receipts format. 
+The runtime must be upgraded to the new primitives before any collator or node is allowed to use 
+the new candidate receipts format. 
 
 ### Validators
 
 To ensure a smooth launch, a new node feature is required. 
-The feature acts as a signal for supporting the new candidate receipts on the node side and can only be safely enabled if at least `2/3 + 1` of the validators are upgraded.
+The feature acts as a signal for supporting the new candidate receipts on the node side and can 
+only be safely enabled if at least `2/3 + 1` of the validators are upgraded.
 
-Once enabled, the validators will skip checking the collator signature when processing the candidate receipts and verify the `CoreIndex` and `SessionIndex` fields if present in the receipt.
+Once enabled, the validators will skip checking the collator signature when processing the 
+candidate receipts and verify the `CoreIndex` and `SessionIndex` fields if present in the receipt.
 
-No new implementation of networking protocol versions for collation and validation are required.
-
-### Parachains
-
-The implementation of this RFC will supersede the Elastic MVP feature that relies on injecting a core index in the `validator_indices` fields of the `BackedCandidate` primitive. Elastic parachains must upgrade to use the new receipt format.
+No new implementation of networking protocol versions for collation and validation is required.
 
 ### Tooling
 
-Any tooling that decodes UMP XCM messages needs an update to support or ignore the new UMP messages, but they should be fine to decode the regular XCM messages that come before the separator.
+Any tooling that decodes UMP XCM messages needs an update to support or ignore the new UMP 
+messages, but they should be fine to decode the regular XCM messages that come before the 
+separator.
 
 ## Prior Art and References
 
-Forum discussion about a new `CandidateReceipt` format: https://forum.polkadot.network/t/pre-rfc-discussion-candidate-receipt-format-v2/3738
+Forum discussion about a new `CandidateReceipt` format:
+ https://forum.polkadot.network/t/pre-rfc-discussion-candidate-receipt-format-v2/3738
 
 ## Unresolved Questions
 
@@ -238,7 +280,10 @@ N/A
 
 ## Future Directions and Related Material
 
-The implementation is extensible and future proof to some extent. With minimal or no breaking changes, additional fields can be added in the candidate descriptor until the reserved space is exhausted
+The implementation is extensible and future proof to some extent. With minimal or no breaking 
+changes, additional fields can be added in the candidate descriptor until the reserved space is 
+exhausted
 
-At this point there is a simple way to determine the version of the receipt, by testing for zeroed reserved bytes in the
-descriptor. Future versions of the receipt can be implemented and identified by using the `version` field of the descirptor introduced in this RFC.
+At this point there is a simple way to determine the version of the receipt, by testing for zeroed 
+reserved bytes in the descriptor. Future versions of the receipt can be implemented and identified 
+by using the `version` field of the descirptor introduced in this RFC.

--- a/text/0103-introduce-core-index-commitment.md
+++ b/text/0103-introduce-core-index-commitment.md
@@ -69,7 +69,8 @@ UMP queue by outputting them in [upward_messages](https://github.com/paritytech/
 
 The UMP queue layout is changed to allow the relay chain to receive both the XCM messages and
 `UMPSignal` messages. An empty message (empty `Vec<u8>`) is used to mark the end of XCM messages and
-the start of `UMPSignal` messages.
+the start of `UMPSignal` messages.The `UMPSignal` is optional and can be omitted by parachains
+not using elastic scaling.
 
 This way of representing the new messages has been chosen over introducing an enum wrapper to
 minimize breaking changes of XCM message decoding in tools like Subscan for example.
@@ -236,9 +237,9 @@ provides the best latency while picking older relay parents avoids re-orgs.
 
 ## Ergonomics
 
-It is mandatory for elastic parachains to switch to the new receipt format. It is optional but
-desired that all parachains switch to the new receipts for providing the session index for
-disputes.
+It is mandatory for elastic parachains to switch to the new receipt format and commit to a
+core by sending the `UMPSignal::SelectCore` message. It is optional but desired that all
+parachains switch to the new receipts for providing the session index for disputes.
 
 The implementation of this RFC itself must not introduce any breaking changes for the parachain
 runtime or collator nodes.


### PR DESCRIPTION
Following the discussion on https://github.com/polkadot-fellows/RFCs/issues/92, this is a proposal to introduce the required core index commitments to make elastic scaling work securely with open collator sets.