### PR TITLE
Handle filenames with whitespaces in the RFC book

### DIFF
--- a/.github/scripts/build-mdbook-summary.js
+++ b/.github/scripts/build-mdbook-summary.js
@@ -26,7 +26,9 @@ module.exports = async ({github, context}) => {
       }
       // Relative path, without the src prefix (format required by mdbook)
       const relativePath = filePath.replace("mdbook/src/", "")
-      fs.appendFileSync(summaryPath, `- [${title}](${relativePath})\n`)
+      // Wrapping the path allows for whitespaces in the title.
+      const target = `<${relativePath}>`
+      fs.appendFileSync(summaryPath, `- [${title}](${target})\n`)
     }
   }
 

--- a/.github/scripts/build-mdbook-summary.js
+++ b/.github/scripts/build-mdbook-summary.js
@@ -26,7 +26,7 @@ module.exports = async ({github, context}) => {
       }
       // Relative path, without the src prefix (format required by mdbook)
       const relativePath = filePath.replace("mdbook/src/", "")
-      // Wrapping the path allows for whitespaces in the title.
+      // Wrapping the path allows for whitespaces in the filename.
       const target = `<${relativePath}>`
       fs.appendFileSync(summaryPath, `- [${title}](${target})\n`)
     }


### PR DESCRIPTION
With a recent PR that has spaces in the RFC filename, the RFC book generation script started failing - this fixes it.